### PR TITLE
Rollback fix, pod logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.0.22] 2024-8-5
+## [1.0.23] 2024-8-5
 
 ### Added
 
@@ -18,6 +18,7 @@
 ### Updated
 
 - `Get-DeploymentStatus` now uses jsonpath filter to get the replicaset for the deploy, instead of filtering in PowerShell
+- `Write-PodLog` won't write an error if the pod is in ContainerCreating state
 
 ## [1.0.21] 2024-7-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Test cases when nothing changes in a deployment
 - Verbose logging of most kubectl commands
-- LogFilename parameter to Get-JobStatus, Get-PodStatus, and Write-PodLog
+- LogFileFolder parameter to Get-JobStatus, Get-PodStatus, and Write-PodLog
 - Added --wait to helm rollback
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
 # Change Log
 
-## [1.0.22] 2024-8-1
+## [1.0.22] 2024-8-5
 
 ### Added
 
-- Test cases when nothing changes in a deployment
+- Test cases for when nothing changes in a deployment
 - Verbose logging of most kubectl commands
-- LogFileFolder parameter to Invoke-HelmUpgrade, Get-DeploymentStatus, Get-JobStatus, Get-PodStatus, and Write-PodLog
-- --wait to helm rollback
-- ToString to PodStatus for better viewing of the output object
+- `LogFileFolder` parameter to `Invoke-HelmUpgrade`, `Get-DeploymentStatus`, `Get-JobStatus`, `Get-PodStatus`, and `Write-PodLog`
+- `--wait` to helm rollback
+- `ToString` to `PodStatus` class for better viewing of the output object
 
 ### Fixed
 
 - Handle case when duplicate env vars of different case and JSON conversion fails
 - Bug when rolling back on first install
+
+### Updated
+
+- `Get-DeploymentStatus` now uses jsonpath filter to get the replicaset for the deploy, instead of filtering in PowerShell
 
 ## [1.0.21] 2024-7-15
 
@@ -23,19 +27,19 @@
 
 ### Updated
 
-- Get-PodStatus has better handling for scheduling errors, such as taints, memory, etc.
+- `Get-PodStatus` has better handling for scheduling errors, such as taints, memory, etc.
 - Logging improvements:
   - Footer always matches the header now
   - Use box drawing characters in header and footer to be cleaner
-  - Removed output file logging code since Start-Transcript works fine
-  - Removed timestamps for TF_BUILD environment since it's already in the log
+  - Removed output file logging code since `Start-Transcript` works fine
+  - Removed timestamps for `TF_BUILD` environment since it's already in the log
 
 ## [1.0.18] 2024-7-12
 
 ### Added
 
 - Get-JobStatus added to check the status of a K8s job
-- Better support in Get-PodStatus for checking the status of a job started via Helm or a kubectl apply
+- Better support in `Get-PodStatus` for checking the status of a job started via Helm or a kubectl apply
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log
 
-## [1.0.22] 2024-7-25
+## [1.0.22] 2024-7-30
 
 ### Added
 
 - Test cases when nothing changes in a deployment
 - Verbose logging of most kubectl commands
+- LogFilename parameter to Get-JobStatus, Get-PodStatus, and Write-PodLog
+- Added --wait to helm rollback
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [1.0.22] 2024-7-25
+
+### Added
+
+- Test cases when nothing changes in a deployment
+- Verbose logging of most kubectl commands
+
+### Fixed
+
+- Handle case when duplicate env vars of different case and JSON conversion fails
+- Bug when rolling back on first install
+
 ## [1.0.21] 2024-7-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Change Log
 
-## [1.0.22] 2024-7-30
+## [1.0.22] 2024-8-1
 
 ### Added
 
 - Test cases when nothing changes in a deployment
 - Verbose logging of most kubectl commands
-- LogFileFolder parameter to Get-JobStatus, Get-PodStatus, and Write-PodLog
-- Added --wait to helm rollback
+- LogFileFolder parameter to Invoke-HelmUpgrade, Get-DeploymentStatus, Get-JobStatus, Get-PodStatus, and Write-PodLog
+- --wait to helm rollback
+- ToString to PodStatus for better viewing of the output object
 
 ### Fixed
 

--- a/DevOps/Helm/minimal_values.yaml
+++ b/DevOps/Helm/minimal_values.yaml
@@ -97,6 +97,8 @@ env:
   deployTime: "00:00:00"
   test1: "testValue1"
   test2: "testValue2"
+  test3: "testValue3"
+  TEST3: "TESTVALUE3"
   test1NoQuotes: $(TEST1) # but we quote in chart
   # cannot use $() for anything but constant values, no CM or Secret refs
   DOTNET_USE_POLLING_FILE_WATCHER: "true"

--- a/K8sUtils/K8sUtils.psd1
+++ b/K8sUtils/K8sUtils.psd1
@@ -12,7 +12,7 @@
 RootModule = 'K8sUtils.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.21'
+ModuleVersion = '1.0.22'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/K8sUtils/K8sUtils.psd1
+++ b/K8sUtils/K8sUtils.psd1
@@ -12,7 +12,7 @@
 RootModule = 'K8sUtils.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.22'
+ModuleVersion = '1.0.23'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/K8sUtils/private/Classes.ps1
+++ b/K8sUtils/private/Classes.ps1
@@ -74,6 +74,7 @@ class PodStatus
     [ContainerStatus[]] $ContainerStatuses
     [ContainerStatus[]] $InitContainerStatuses
     [string[]] $LastBadEvents
+    [string] $PodLogFile
 
     [void] DetermineStatus() {
         if (($this.ContainerStatuses | Where-Object { $_ -and $_.Status -eq [Status]::Crash }) -or

--- a/K8sUtils/private/Classes.ps1
+++ b/K8sUtils/private/Classes.ps1
@@ -76,6 +76,10 @@ class PodStatus
     [string[]] $LastBadEvents
     [string] $PodLogFile
 
+    [string] ToString() {
+        return "{$($this.PodName) $($this.Status)}"
+    }
+
     [void] DetermineStatus() {
         if (($this.ContainerStatuses | Where-Object { $_ -and $_.Status -eq [Status]::Crash }) -or
             ($this.InitContainerStatuses | Where-Object { $_ -and $_.Status -eq [Status]::Crash }) ) {

--- a/K8sUtils/private/Write-Header.ps1
+++ b/K8sUtils/private/Write-Header.ps1
@@ -4,6 +4,13 @@ $script:FooterPrefix = ""
 $script:AddDate = $true
 $script:Dashes = 30
 
+function Get-TempLogFile($prefix = "k8s-") {
+    $temp = [System.IO.Path]::GetTempFileName()
+    $ret = Join-Path( Split-Path -Path $temp -Parent) "$prefix$(Split-Path -Path $temp -Leaf)"
+    $script:OutputFile = $ret
+    return $ret
+}
+
 function Write-MyHost {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Write-Information need ANSI resets')]
     [CmdletBinding()]

--- a/K8sUtils/private/Write-PodLog.ps1
+++ b/K8sUtils/private/Write-PodLog.ps1
@@ -32,7 +32,7 @@ function Write-PodLog {
         Where-Object { $_ -NotMatch 'Error.*: (PodInitializing|ContainerCreating)' } | Write-Plain
     if ($LogFileFolder) {
         Stop-Transcript | Out-Null
-        $logFilename = "$LogFileFolder/$PodName.log"
+        $logFilename = Join-Path $LogFileFolder "$PodName.log"
         $end = $false
         # filter out the transcript header and footer
         Get-Content $tempFile | Select-Object -Skip 4 | ForEach-Object {

--- a/K8sUtils/private/Write-PodLog.ps1
+++ b/K8sUtils/private/Write-PodLog.ps1
@@ -31,6 +31,7 @@ function Write-PodLog {
         $msg = "Error getting logs for pod $PodName (exit = $getLogsExitCode), checking status"
         Write-Header $msg -LogLevel error
         # TODO if you have multiple containers, this returns multiple chunks of json, but not in an array
+        Write-Verbose "kubectl get pod $PodName -o jsonpath='{.status.containerStatuses.*.state}'"
         $state = ,(kubectl get pod $PodName -o jsonpath="{.status.containerStatuses.*.state}" | ConvertFrom-Json -Depth 5)
         foreach ($s in $state) {
             # can have running, waiting, or terminated properties

--- a/K8sUtils/private/Write-PodLog.ps1
+++ b/K8sUtils/private/Write-PodLog.ps1
@@ -33,9 +33,10 @@ function Write-PodLog {
     if ($LogFileFolder) {
         Stop-Transcript | Out-Null
         $logFilename = "$LogFileFolder/$PodName.log"
+        $end = $false
+        # filter out the transcript header and footer
         Get-Content $tempFile | Select-Object -Skip 4 | ForEach-Object {
-            if ($_ -eq '**********************') { break }
-            $_
+            if ($end -or $_ -eq '**********************') { $end = $true } else { $_ }
         } | Set-Content $logFilename
         Remove-Item $tempFile -ErrorAction SilentlyContinue
     }

--- a/K8sUtils/private/rollbackAndWarn.ps1
+++ b/K8sUtils/private/rollbackAndWarn.ps1
@@ -1,0 +1,49 @@
+# called by Invoke-HelmUpgrade
+function rollbackAndWarn {
+    [CmdletBinding()]
+    param ($SkipRollbackOnError, $releaseName, $msg, $prevVersion)
+
+    try {
+        Write-Verbose "helm status --namespace $Namespace $ReleaseName -o json"
+        $currentReleaseVersion = helm status --namespace $Namespace $ReleaseName -o json | ConvertFrom-Json -Depth 10 -AsHashtable # AsHashTable allows for duplicate keys in env, etc.
+        if (!$currentReleaseVersion -or !($currentReleaseVersion.ContainsKey('version'))) {
+            Write-Status "Unexpected response from helm status, not rolling back" -LogLevel warning
+            Write-Status "Current helm release: $($currentReleaseVersion | ConvertTo-Json -Depth 20 -EnumsAsStrings)"
+            return [RollbackStatus]::HelmStatusFailed
+        }
+        Write-Verbose "Current version of $ReleaseName is $($currentReleaseVersion.version)"
+        if (!$currentReleaseVersion -or $currentReleaseVersion.version -eq $prevVersion) {
+            Write-Status "No change in release '$ReleaseName', not rolling back" -LogLevel warning
+            # throw "$msg, no change"
+            Write-Warning "$msg, no change"
+            return [RollbackStatus]::NoChange
+        }
+
+        if (!$SkipRollbackOnError) {
+            Write-Header "Rolling back release '$ReleaseName' due to errors" -LogLevel Error
+            $errFile = Get-TempLogFile
+            helm rollback $ReleaseName --wait 2>&1 | Tee-Object $errFile | Write-MyHost
+            $exit = $LASTEXITCODE
+            $content = Get-Content $errFile -Raw
+            if ($exit -ne 0 -and ($content -like '*Error: release has no 0 version*' -or $content -like '*Error: release: not found*')) {
+                Write-Verbose "Last exit code on rollback was $exit."
+                Write-Status "helm rollback failed, trying uninstall" -LogLevel Error -Char '-'
+                helm uninstall $ReleaseName 2>&1 | Write-MyHost
+            }
+            Remove-Item $errFile -ErrorAction SilentlyContinue
+            Write-Footer "End rolling back release '$ReleaseName' due to errors"
+            # throw "$msg, rolled back"
+            Write-Warning "$msg, rolled back"
+            return [RollbackStatus]::RolledBack
+        } else {
+            # throw "$msg, but not rolling back since -SkipRollbackOnError was specified"
+            Write-Warning "$msg, but not rolling back since -SkipRollbackOnError was specified"
+            return [RollbackStatus]::Skipped
+        }
+        return [RollbackStatus]::DeployedOk
+    } catch {
+        Write-Warning "Caught error rolling back in catch"
+        Write-Error "$_`n$($_.ScriptStackTrace)"
+        return [RollbackStatus]::HelmStatusFailed
+    }
+}

--- a/K8sUtils/public/Add-Annotation.ps1
+++ b/K8sUtils/public/Add-Annotation.ps1
@@ -51,6 +51,7 @@ param(
         throw "kubectl is not installed"
     }
 
+    Write-Verbose "kubectl get $ResourceName -n $Namespace -o json"
     $resources = (kubectl get $ResourceName -n $Namespace -o json | ConvertFrom-Json).items
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to retrieve $ResourceName in $Namespace"

--- a/K8sUtils/public/Get-DeploymentStatus.ps1
+++ b/K8sUtils/public/Get-DeploymentStatus.ps1
@@ -14,6 +14,9 @@ Seconds to wait for the deployment to be ready
 .PARAMETER PollIntervalSec
 How often to poll for pod status. Defaults to 5
 
+.PARAMETER LogFileFolder
+If specified, pod logs will be written to this folder
+
 .EXAMPLE
 Get-DeploymentStatus -TimeoutSec $timeoutSec `
                      -Selector "app.kubernetes.io/instance=$ReleaseName,app.kubernetes.io/name=$ChartName"
@@ -35,7 +38,8 @@ function Get-DeploymentStatus {
         [string] $Selector,
         [string] $Namespace = "default",
         [int] $TimeoutSec = 30,
-        [int] $PollIntervalSec = 5
+        [int] $PollIntervalSec = 5,
+        [string] $LogFileFolder
     )
 
     Set-StrictMode -Version Latest
@@ -85,7 +89,8 @@ function Get-DeploymentStatus {
                          -ReplicaCount $replicas `
                          -Namespace $Namespace `
                          -TimeoutSec $TimeoutSec `
-                         -PollIntervalSec $PollIntervalSec
+                         -PollIntervalSec $PollIntervalSec `
+                         -LogFileFolder $LogFileFolder
 
     Write-Footer
     Write-Verbose "ret is $($ret | out-string)"

--- a/K8sUtils/public/Get-JobStatus.ps1
+++ b/K8sUtils/public/Get-JobStatus.ps1
@@ -17,8 +17,8 @@ Timeout in seconds for waiting on the pods. Defaults to 600
 .PARAMETER Namespace
 K8s namespace to use, defaults to default
 
-.PARAMETER LogFilename
-If specified, logs will be written to this file
+.PARAMETER LogFileFolder
+If specified, pod logs will be written to this folder
 
 .EXAMPLE
 Get-JobStatus -JobName test-job
@@ -26,7 +26,7 @@ Get-JobStatus -JobName test-job
 Get the status of the pods for the job test-job
 
 .OUTPUTS
-Array of PodStatus object
+Array of PodStatus objects
 #>
 function Get-JobStatus {
     [CmdletBinding()]
@@ -39,7 +39,7 @@ function Get-JobStatus {
         [int] $PollIntervalSec = 5,
         [int] $TimeoutSec = 600,
         [string] $Namespace = "default",
-        [string] $LogFilename
+        [string] $LogFileFolder
 
     )
     $ErrorActionPreference = 'Stop'
@@ -60,7 +60,7 @@ function Get-JobStatus {
             -TimeoutSec $TimeoutSec `
             -PollIntervalSec $PollIntervalSec `
             -Namespace $Namespace `
-            -LogFilename $LogFilename `
+            -LogFileFolder $LogFileFolder `
 
     } else {
         Write-Warning "Job $JobName not found in namespace $Namespace"

--- a/K8sUtils/public/Get-JobStatus.ps1
+++ b/K8sUtils/public/Get-JobStatus.ps1
@@ -41,6 +41,7 @@ function Get-JobStatus {
     $ErrorActionPreference = 'Stop'
     Set-StrictMode -Version Latest
 
+    Write-Verbose "kubectl get job $JobName --namespace $Namespace -o json"
     $job = kubectl get job $JobName --namespace $Namespace -o json | ConvertFrom-Json
 
     if ($job) {

--- a/K8sUtils/public/Get-JobStatus.ps1
+++ b/K8sUtils/public/Get-JobStatus.ps1
@@ -17,6 +17,9 @@ Timeout in seconds for waiting on the pods. Defaults to 600
 .PARAMETER Namespace
 K8s namespace to use, defaults to default
 
+.PARAMETER LogFilename
+If specified, logs will be written to this file
+
 .EXAMPLE
 Get-JobStatus -JobName test-job
 
@@ -35,7 +38,8 @@ function Get-JobStatus {
         [ValidateRange(1, 600)]
         [int] $PollIntervalSec = 5,
         [int] $TimeoutSec = 600,
-        [string] $Namespace = "default"
+        [string] $Namespace = "default",
+        [string] $LogFilename
 
     )
     $ErrorActionPreference = 'Stop'
@@ -54,7 +58,9 @@ function Get-JobStatus {
             -PodType Job `
             -Verbose:$VerbosePreference `
             -TimeoutSec $TimeoutSec `
-            -PollIntervalSec $PollIntervalSec
+            -PollIntervalSec $PollIntervalSec `
+            -Namespace $Namespace `
+            -LogFilename $LogFilename `
 
     } else {
         Write-Warning "Job $JobName not found in namespace $Namespace"

--- a/K8sUtils/public/Get-JobStatus.ps1
+++ b/K8sUtils/public/Get-JobStatus.ps1
@@ -40,7 +40,6 @@ function Get-JobStatus {
         [int] $TimeoutSec = 600,
         [string] $Namespace = "default",
         [string] $LogFileFolder
-
     )
     $ErrorActionPreference = 'Stop'
     Set-StrictMode -Version Latest

--- a/K8sUtils/public/Get-PodByJobName.ps1
+++ b/K8sUtils/public/Get-PodByJobName.ps1
@@ -15,13 +15,16 @@ An example
 One or more pods for the job
 #>
 function Get-PodByJobName {
+    [CmdletBinding()]
     param (
         [string] $JobName,
         [string] $Namespace = "default"
     )
 
+    Write-Verbose "kubectl get job $JobName --namespace $Namespace -o json"
     $job = kubectl get job $JobName --namespace $Namespace -o json | ConvertFrom-Json
     if ($job) {
+        Write-Verbose "kubectl get pod --namespace $Namespace --selector 'batch.kubernetes.io/controller-uid=$($job.metadata.labels.'batch.kubernetes.io/controller-uid')' -o json"
         (kubectl get pod --namespace $Namespace --selector "batch.kubernetes.io/controller-uid=$($job.metadata.labels.'batch.kubernetes.io/controller-uid')" -o json | ConvertFrom-Json).items
     } else {
         Write-Warning "Job $JobName not found in namespace $Namespace"

--- a/K8sUtils/public/Get-PodEvent.ps1
+++ b/K8sUtils/public/Get-PodEvent.ps1
@@ -33,7 +33,6 @@ function Get-PodEvent {
         [string] $Namespace = "default"
     )
     Write-Verbose "kubectl get events --namespace $Namespace --field-selector `"involvedObject.name=$PodName`" -o json"
-
     $events = kubectl get events --namespace $Namespace --field-selector "involvedObject.name=$PodName" -o json | ConvertFrom-Json
 
     if ($LASTEXITCODE -ne 0) {

--- a/K8sUtils/public/Get-PodStatus.ps1
+++ b/K8sUtils/public/Get-PodStatus.ps1
@@ -98,6 +98,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
     $timedOut = (Get-Date) -gt $timeoutEnd
 
     # $pods = kubectl get pod --namespace $Namespace --selector "$LabelName=$AppName" --field-selector "status.phase!=Running" -o json | ConvertFrom-Json
+    Write-Verbose "kubectl get pod --namespace $Namespace --selector $Selector --sort-by=.metadata.name -o json"
     $pods = kubectl get pod --namespace $Namespace --selector $Selector --sort-by=.metadata.name -o json | ConvertFrom-Json
 
     if (!$pods) {
@@ -204,6 +205,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
 
                 # get latest pod status since sometimes get containerCreating status here
                 $name = $pod.metadata.name
+                Write-Verbose "kubectl get pod --namespace $Namespace $name -o json"
                 $podJson = kubectl get pod --namespace $Namespace $name -o json
                 $pod = $podJson | ConvertFrom-Json
                 if (!$pod -or !(Get-Member -InputObject $pod -Name metadata)) {
@@ -235,7 +237,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
     } # end foreach pod
 
     if ($runningCount -ge $ReplicaCount) {
-        Write-Status "All ${prefix}s ($runningCount/$ReplicaCount) that matched selector $Selector are running`n" -Length 0 -Char '-' -LogLevel normal
+        Write-Status "All ${prefix}s ($runningCount/$ReplicaCount) that matched selector $Selector are running`n" -Length 0 -LogLevel normal
         break
     }
 

--- a/K8sUtils/public/Invoke-HelmUpgrade.ps1
+++ b/K8sUtils/public/Invoke-HelmUpgrade.ps1
@@ -161,14 +161,12 @@ function Invoke-HelmUpgrade {
                 Write-Header "Rolling back release '$ReleaseName' due to errors" -LogLevel Error
                 $errFile = Get-TempLogFile
                 helm rollback $ReleaseName 2>&1 | Tee-Object $errFile | Write-MyHost
-                Get-Content $errFile -Raw | Out-File $tempFile -Append
                 $exit = $LASTEXITCODE
                 $content = Get-Content $errFile -Raw
-                $content | Out-File $OutputFile -Append
                 if ($exit -ne 0 -and ($content -like '*Error: release has no 0 version*' -or $content -like '*Error: release: not found*')) {
                     Write-Verbose "Last exit code on rollback was $exit."
                     Write-Status "helm rollback failed, trying uninstall" -LogLevel Error -Char '-'
-                    helm uninstall $ReleaseName
+                    helm uninstall $ReleaseName 2>&1 | Write-MyHost
                 }
                 Write-Footer "End rolling back release '$ReleaseName' due to errors"
                 # throw "$msg, rolled back"

--- a/K8sUtils/public/Invoke-HelmUpgrade.ps1
+++ b/K8sUtils/public/Invoke-HelmUpgrade.ps1
@@ -159,8 +159,12 @@ function Invoke-HelmUpgrade {
 
             if (!$SkipRollbackOnError) {
                 Write-Header "Rolling back release '$ReleaseName' due to errors" -LogLevel Error
-                helm rollback $ReleaseName 2>&1 | Write-MyHost
+                $errFile = Get-TempLogFile
+                helm rollback $ReleaseName 2>&1 | Tee-Object $errFile | Write-MyHost
+                Get-Content $errFile -Raw | Out-File $tempFile -Append
                 $exit = $LASTEXITCODE
+                $content = Get-Content $errFile -Raw
+                $content | Out-File $OutputFile -Append
                 if ($exit -ne 0 -and ($content -like '*Error: release has no 0 version*' -or $content -like '*Error: release: not found*')) {
                     Write-Verbose "Last exit code on rollback was $exit."
                     Write-Status "helm rollback failed, trying uninstall" -LogLevel Error -Char '-'

--- a/K8sUtils/public/Invoke-HelmUpgrade.ps1
+++ b/K8sUtils/public/Invoke-HelmUpgrade.ps1
@@ -161,7 +161,7 @@ function Invoke-HelmUpgrade {
             if (!$SkipRollbackOnError) {
                 Write-Header "Rolling back release '$ReleaseName' due to errors" -LogLevel Error
                 $errFile = Get-TempLogFile
-                helm rollback $ReleaseName 2>&1 | Tee-Object $errFile | Write-MyHost
+                helm rollback $ReleaseName --wait 2>&1 | Tee-Object $errFile | Write-MyHost
                 $exit = $LASTEXITCODE
                 $content = Get-Content $errFile -Raw
                 if ($exit -ne 0 -and ($content -like '*Error: release has no 0 version*' -or $content -like '*Error: release: not found*')) {

--- a/Tools/Deploy-Minimal.ps1
+++ b/Tools/Deploy-Minimal.ps1
@@ -73,7 +73,8 @@ function Deploy-Minimal {
         [switch] $PassThru,
         [switch] $StartupProbe,
         [switch] $SkipDeploy,
-        [switch] $AlwaysCheckPreHook
+        [switch] $AlwaysCheckPreHook,
+        [switch] $SkipSetStartTime # keeps all manifests the same
 
     )
     Set-StrictMode -Version Latest
@@ -126,7 +127,7 @@ function Deploy-Minimal {
     }
 
     $helmSet += "deployment.enabled=$($SkipDeploy ? "false" : "true")",
-                "env.deployTime=$(Get-Date)",
+                "env.deployTime=$($SkipSetStartTime ? "2024-01-01" : (Get-Date))",
                 "env.failOnStart=$fail",
                 "env.runCount=$RunCount",
                 "image.tag=$ImageTag",

--- a/Tools/Deploy-Minimal.ps1
+++ b/Tools/Deploy-Minimal.ps1
@@ -142,6 +142,7 @@ function Deploy-Minimal {
     $releaseName = "test"
     $chartName = "minimal"
     try {
+        $logFolder = [System.IO.Path]::GetTempPath()
         $ret = Invoke-HelmUpgrade -ValueFile "minimal_values.yaml" `
                            -ChartName $chartName `
                            -ReleaseName $releaseName `
@@ -155,7 +156,9 @@ function Deploy-Minimal {
                            -DryRun:$DryRun `
                            -SkipRollbackOnError:$SkipRollbackOnError `
                            -ColorType $ColorType `
-                           -Verbose:$VerbosePreference
+                           -Verbose:$VerbosePreference `
+                           -LogFileFolder $logFolder
+        Write-Host "Logs for job are in $logFolder" -ForegroundColor Cyan
         if ($PassThru) {
             $ret
         } else {

--- a/Tools/Deploy-MinimalJobK8s.ps1
+++ b/Tools/Deploy-MinimalJobK8s.ps1
@@ -115,15 +115,15 @@ $initContainer
             throw "kubectl apply failed"
         }
 
-        $logFile = [System.IO.Path]::GetTempFileName()
+        $logFolder = [System.IO.Path]::GetTempPath()
         Get-JobStatus -JobName "test-job" `
                       -ReplicaCount 1 `
                       -Verbose:$VerbosePreference `
                       -TimeoutSec $TimeoutSecs `
                       -PollIntervalSec $PollIntervalSec `
                       -Namespace "default" `
-                      -LogFilename $logFile
-        Write-Host "Logs for job are in $logFile" -ForegroundColor Cyan
+                      -LogFileFolder $logFolder
+        Write-Host "Logs for job are in $logFolder" -ForegroundColor Cyan
     } catch {
         Write-Error "Error! $_`n$($_.ScriptStackTrace)"
     } finally {

--- a/Tools/Deploy-MinimalJobK8s.ps1
+++ b/Tools/Deploy-MinimalJobK8s.ps1
@@ -107,6 +107,7 @@ $initContainer
         return
     }
     Write-Verbose $manifest
+    $null = kubectl delete job test-job --ignore-not-found # so don't find prev one deployed with helm, which will fail
     try {
         $output = $manifest | kubectl apply -f - -o yaml
         Write-Verbose ($output | Out-String)

--- a/Tools/Deploy-MinimalJobK8s.ps1
+++ b/Tools/Deploy-MinimalJobK8s.ps1
@@ -115,11 +115,15 @@ $initContainer
             throw "kubectl apply failed"
         }
 
+        $logFile = [System.IO.Path]::GetTempFileName()
         Get-JobStatus -JobName "test-job" `
                       -ReplicaCount 1 `
                       -Verbose:$VerbosePreference `
                       -TimeoutSec $TimeoutSecs `
-                      -PollIntervalSec $PollIntervalSec
+                      -PollIntervalSec $PollIntervalSec `
+                      -Namespace "default" `
+                      -LogFilename $logFile
+        Write-Host "Logs for job are in $logFile" -ForegroundColor Cyan
     } catch {
         Write-Error "Error! $_`n$($_.ScriptStackTrace)"
     } finally {

--- a/Tools/Get-PodStatusOld.ps1
+++ b/Tools/Get-PodStatusOld.ps1
@@ -11,7 +11,7 @@ $pods = @(k get pod --no-headers -o custom-columns=T:.metadata.name,S:.status.co
 Write-Verbose "Pods: $($pods.count)"
 foreach ($p in $pods) {
     Write-Verbose "  Pod: $($p)"
-    $events = @(k get event --field-selector "involvedObject.name=$($pods[0])" -o json | convertfrom-json)
+    $events = @(kubectl get event --field-selector "involvedObject.name=$($pods[0])" -o json | convertfrom-json)
     foreach ($e in $events) {
         Write-Verbose "Events for pod: $($e.items.count)"
         foreach ($ee in $e.items) {

--- a/Tools/JobDeployK8s.tests.ps1
+++ b/Tools/JobDeployK8s.tests.ps1
@@ -14,6 +14,8 @@ Describe "Deploys Minimal API" {
         $deploy = Deploy-MinimalJobK8s
 
         Test-Pod $deploy -nameLike 'test-job-*' -containerName 'test-job' -status 'Completed' -containerStatus 'Completed'
+        $deploy.PodLogFile | Should -Not -BeNullOrEmpty
+        Test-Path $deploy.PodLogFile | Should -Be $true
     } -Tag 'Happy','k1'
 
     It "runs without init ok" {

--- a/Tools/JobDeployK8s.tests.ps1
+++ b/Tools/JobDeployK8s.tests.ps1
@@ -1,7 +1,7 @@
 # Import the script that defines the Deploy-MinimalJobK8s function
 BeforeAll {
-    Import-Module  $PSScriptRoot\..\K8sUtils\K8sUtils.psm1 -Force -ArgumentList $true
     Import-Module  $PSScriptRoot\Minimal.psm1 -Force -ArgumentList $true
+    Import-Module  $PSScriptRoot\..\K8sUtils\K8sUtils.psm1 -Force -ArgumentList $true
 
     $env:invokeHelmAllowLowTimeouts = $true
 

--- a/Tools/MinimalDeploy.tests.ps1
+++ b/Tools/MinimalDeploy.tests.ps1
@@ -201,5 +201,13 @@ Describe "Deploys Minimal API" {
             kubectl taint nodes $node key1:NoSchedule-
         }
     } -Tag 'Sad','t24'
+
+    It "tests rollback if uninstalled" {
+        helm uninstall test
+        $deploy = Deploy-Minimal -PassThru -SkipInit -SkipPreHook -Fail
+        Test-Deploy $deploy -Running $false -RollbackStatus 'RolledBack'
+
+        Test-MainPod $deploy.PodStatuses[0] -status 'Crash'
+   } -Tag 'Sad','t25'
 }
 

--- a/Tools/MinimalDeploy.tests.ps1
+++ b/Tools/MinimalDeploy.tests.ps1
@@ -202,12 +202,28 @@ Describe "Deploys Minimal API" {
         }
     } -Tag 'Sad','t24'
 
+    It "tests no changes" {
+        $deploy1 = Deploy-Minimal -PassThru -SkipPreHook -SkipInit -TimeoutSecs 10 -SkipSetStartTime
+
+        Test-Deploy $deploy1
+
+        Test-MainPod $deploy1.PodStatuses[0]
+
+        $deploy2 = Deploy-Minimal -PassThru -SkipPreHook -SkipInit -TimeoutSecs 10 -SkipSetStartTime
+
+        Test-Deploy $deploy2
+
+        Test-MainPod $deploy2.PodStatuses[0]
+
+        $deploy1.PodStatuses[0].PodName | Should -Be $deploy2.PodStatuses[0].PodName
+    } -Tag 'Happy','t25'
+    
     It "tests rollback if uninstalled" {
         helm uninstall test
         $deploy = Deploy-Minimal -PassThru -SkipInit -SkipPreHook -Fail
         Test-Deploy $deploy -Running $false -RollbackStatus 'RolledBack'
 
         Test-MainPod $deploy.PodStatuses[0] -status 'Crash'
-   } -Tag 'Sad','t25'
+   } -Tag 'Sad','t26'
 }
 

--- a/Tools/MinimalDeploy.tests.ps1
+++ b/Tools/MinimalDeploy.tests.ps1
@@ -196,7 +196,7 @@ Describe "Deploys Minimal API" {
 
     It "tests taints" {
         $node = k get node -o jsonpath="{.items[0].metadata.name}"
-        Write-Host kubectl taint nodes $node key1=value1:NoSchedule
+        kubectl taint nodes $node key1=value1:NoSchedule
         try {
             $deploy = Deploy-Minimal -PassThru -SkipPreHook -SkipInit -RunCount 1 -PreHookTimeoutSecs 5 -TimeoutSecs 5
             Test-Deploy $deploy -Running $false -PodCount 1 -RollbackStatus 'RolledBack'

--- a/run.ps1
+++ b/run.ps1
@@ -84,7 +84,7 @@ try {
                     try {
                         if ($prerelease) {
                             Copy-Item K8sUtils.psd1 K8sUtils.psd1.bak -Force
-                            (Get-Content K8sUtils.psd1 -Raw) -replace '# Prerelease = ''''', 'Prerelease = ''prelease''' | Set-Content K8sUtils.psd1 -Encoding 'UTF8' -NoNewline
+                            (Get-Content K8sUtils.psd1 -Raw) -replace '# Prerelease = ''''', 'Prerelease = ''prerelease''' | Set-Content K8sUtils.psd1 -Encoding 'UTF8' -NoNewline
                         }
                         Publish-Module -Repository $Repository -Path . -NuGetApiKey $NuGetApiKey
                     } finally {

--- a/run.ps1
+++ b/run.ps1
@@ -99,7 +99,7 @@ try {
                 executeSB  {
                     $result = Invoke-Pester -PassThru -Tag $tag -Path Tools/MinimalDeploy.tests.ps1
                     $i = 0
-                    Write-Information ($result.tests | Where-Object { $i+=1; $_.executed -and !$_.passed } | Select-Object name, @{n='i';e={$i}},@{n='tags';e={$_.tag -join ','}}, @{n='Error';e={$_.ErrorRecord.DisplayErrorMessage -Replace [Environment]::NewLine,"" }} | Out-String)  -InformationAction Continue
+                    Write-Information ($result.tests | Where-Object { $i+=1; $_.executed -and !$_.passed } | Select-Object name, @{n='i';e={$i-1}},@{n='tags';e={$_.tag -join ','}}, @{n='Error';e={$_.ErrorRecord.DisplayErrorMessage -Replace [Environment]::NewLine,"" }} | Out-String)  -InformationAction Continue
                     Write-Information "Test results: are in `$test_results" -InformationAction Continue
                     $global:test_results = $result
                 }


### PR DESCRIPTION
### Added

- Test cases for when nothing changes in a deployment
- Verbose logging of most kubectl commands
- `LogFileFolder` parameter to `Invoke-HelmUpgrade`, `Get-DeploymentStatus`, `Get-JobStatus`, `Get-PodStatus`, and `Write-PodLog`
- `--wait` to helm rollback
- `ToString` to `PodStatus` class for better viewing of the output object

### Fixed

- Handle case when duplicate env vars of different case and JSON conversion fails
- Bug when rolling back on first install

### Updated

- `Get-DeploymentStatus` now uses jsonpath filter to get the replicaset for the deploy, instead of filtering in PowerShell
- `Write-PodLog` won't write an error if the pod is in ContainerCreating state