### PR TITLE
update version and change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.0.37] 2026-04-27
+## [1.0.37] 2026-06-10
 
 ### Changed
 
@@ -8,6 +8,7 @@
 - Suppress logging header and footer if there are no logs when polling for them.
 - `Set-K8sUtilsConfig -AllowLowTimeouts` switch added instead of using environment variable. This is a breaking change, but only affects testing.
 - Added DELAY_SEC parameter for testing in the minimal app. Depends on using the latest minimal app.
+- Update bad pod reason detection by using restart count
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [1.0.37] 2026-04-27
+
+### Changed
+
+- Update pre-install hook log retrieval to get first lines that may be lost
+- Suppress logging header and footer if there are no logs when polling for them.
+- `Set-K8sUtilsConfig -AllowLowTimeouts` switch added instead of using environment variable. This is a breaking change, but only affects testing.
+- Added DELAY_SEC parameter for testing in the minimal app. Depends on using the latest minimal app.
+
+### Fixed
+
+- Bug in Get-PodStatus the --since parameter was using the wrong variable
+
 ## [1.0.36] 2026-04-06
 
 ### Changed

--- a/DevOps/Helm/templates/preHookJob.yaml
+++ b/DevOps/Helm/templates/preHookJob.yaml
@@ -45,6 +45,8 @@ spec:
         env:
           - name: RUN_COUNT
             value: "{{ .Values.preHook.runCount }}"
+          - name: DELAY_SEC
+            value: "{{ .Values.preHook.delaySec }}"
           - name: FAIL
             value: "{{ .Values.preHook.fail }}"
         volumeMounts:

--- a/K8sUtils/K8sUtils.psd1
+++ b/K8sUtils/K8sUtils.psd1
@@ -12,7 +12,7 @@
 RootModule = 'K8sUtils.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.36'
+ModuleVersion = '1.0.37'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/K8sUtils/private/Classes.ps1
+++ b/K8sUtils/private/Classes.ps1
@@ -36,12 +36,22 @@ function mapContainerStatus($containerStatus) {
     if ($containerStatus.ready) {
         return [Status]::Running
     }
-    if ((Get-Member -InputObject $containerStatus.state -Name 'waiting') -and $containerStatus.state.waiting) {
-        return $containerStatus.state.waiting.reason -eq "CrashLoopBackOff" ? [Status]::Crash : [Status]::ConfigError,($containerStatus.state.waiting.reason)
+
+    if ($waiting = Get-Value $containerStatus 'state.waiting.reason') {
+        return $waiting -eq "CrashLoopBackOff" ? [Status]::Crash : [Status]::ConfigError,($waiting)
     }
-    if ((Get-Member -InputObject $containerStatus.state -Name 'terminated') -and $containerStatus.state.terminated) {
-        return $containerStatus.state.terminated.reason -eq 'completed' ? [Status]::Running : [Status]::Crash,($containerStatus.state.terminated.reason)
+
+    if ($restartCount = Get-Value $containerStatus 'restartCount') {
+        if ($lastState = Get-Value $containerStatus 'lastState.terminated.reason') {
+            return [Status]::Crash,$lastState
+        }
+        return [Status]::Crash,"Restarted $restartCount times"
     }
+
+    if ($terminated = Get-Value $containerStatus 'lastState.terminated.reason') {
+        return $terminated -eq 'completed' ? [Status]::Running : [Status]::Crash,($terminated)
+    }
+
     return [Status]::Unknown,"Possible timeout or probe failure"
 }
 

--- a/K8sUtils/private/Classes.ps1
+++ b/K8sUtils/private/Classes.ps1
@@ -48,6 +48,10 @@ function mapContainerStatus($containerStatus) {
         return [Status]::Crash,"Restarted $restartCount times"
     }
 
+    if ($terminated = Get-Value $containerStatus 'state.terminated.reason') {
+        return $terminated -eq 'completed' ? [Status]::Running : [Status]::Crash,($terminated)
+    }
+
     if ($terminated = Get-Value $containerStatus 'lastState.terminated.reason') {
         return $terminated -eq 'completed' ? [Status]::Running : [Status]::Crash,($terminated)
     }

--- a/K8sUtils/private/Get-ObjectPropertyValue.ps1
+++ b/K8sUtils/private/Get-ObjectPropertyValue.ps1
@@ -1,0 +1,67 @@
+<#
+.SYNOPSIS
+Retrieves the value of a nested property from an object using a dot-separated property path.
+
+.DESCRIPTION
+Traverses an object (including nested hashtables and PSObjects) to extract the value at the specified property path. Handles missing properties and collections gracefully, with optional error throwing.
+
+.PARAMETER Object
+The object to traverse.
+
+.PARAMETER PropertyPath
+Dot-separated string specifying the property path (e.g., 'foo.bar.baz').
+
+.PARAMETER ThrowIfNotFound
+If specified, throws an error when a property in the path is not found. Otherwise, returns $null.
+
+.OUTPUTS
+The value of the property if found; otherwise $null or throws if -ThrowIfNotFound is set.
+
+.EXAMPLE
+Get-ObjectPropertyValue -Object $obj -PropertyPath 'foo.bar.baz'
+
+.NOTES
+Supports both hashtables/dictionaries and PSObjects. Does not support property access on collections.
+#>
+function Get-ObjectPropertyValue {
+    param (
+        [Parameter(Mandatory)]
+        [object] $Object,
+        [Parameter(Mandatory)]
+        [string] $PropertyPath,
+        [switch] $ThrowIfNotFound
+    )
+    Set-StrictMode -Version Latest
+
+    $currentValue = $Object
+    foreach ($property in $PropertyPath -split '\.') {
+        if ($currentValue -is [System.Collections.IDictionary]) {
+            if ($currentValue.Contains($property)) {
+                $currentValue = $currentValue[$property]
+            } else {
+                if ($ThrowIfNotFound) {
+                    throw "Property '$property' not found in object."
+                }
+                return $null
+            }
+        } elseif ($currentValue -is [System.Collections.IEnumerable] -and -not ($currentValue -is [string])) {
+            # If the current value is a collection, we can't access a property on it directly
+            if ($ThrowIfNotFound) {
+                throw "Property '$property' not found in object."
+            }
+            return $null
+        } else {
+            if ($currentValue -and $currentValue.PSObject.Properties[$property]) {
+                $currentValue = $currentValue.$property
+            } else {
+                if ($ThrowIfNotFound) {
+                    throw "Property '$property' not found in object."
+                }
+                return $null
+            }
+        }
+    }
+    return $currentValue
+}
+New-Alias -Name gov -Value Get-ObjectPropertyValue -Force
+New-Alias -Name Get-Value -Value Get-ObjectPropertyValue -Force

--- a/K8sUtils/private/Get-TerminalContainerState.ps1
+++ b/K8sUtils/private/Get-TerminalContainerState.ps1
@@ -1,0 +1,28 @@
+function Get-TerminalContainerState($pod) {
+    $terminalWaitingReasons = @(
+        'CrashLoopBackOff', 'ImagePullBackOff', 'ErrImagePull',
+        'CreateContainerConfigError', 'InvalidImageName', 'RunContainerError'
+    )
+    $allStatuses = @()
+    if (Get-Member -InputObject $pod.status -Name containerStatuses -ErrorAction SilentlyContinue) {
+        $allStatuses += $pod.status.containerStatuses | ForEach-Object { @{ cs = $_; kind = "container" } }
+    }
+    if (Get-Member -InputObject $pod.status -Name initContainerStatuses -ErrorAction SilentlyContinue) {
+        $allStatuses += $pod.status.initContainerStatuses | ForEach-Object { @{ cs = $_; kind = "init container" } }
+    }
+    foreach ($entry in $allStatuses) {
+        $cs = $entry.cs
+        if ((Get-Member -InputObject $cs.state -Name waiting -ErrorAction SilentlyContinue) -and $cs.state.waiting) {
+            if ($cs.state.waiting.reason -in $terminalWaitingReasons) {
+                return @{ ContainerName = $cs.name; Kind = $entry.kind; Reason = $cs.state.waiting.reason; Message = $cs.state.waiting.message }
+            }
+        }
+        if ((Get-Member -InputObject $cs.state -Name terminated -ErrorAction SilentlyContinue) -and $cs.state.terminated) {
+            $t = $cs.state.terminated
+            if ($t.exitCode -ne 0 -and $t.reason -ne 'Completed') {
+                return @{ ContainerName = $cs.name; Kind = $entry.kind; Reason = $t.reason; Message = "exitCode=$($t.exitCode)" }
+            }
+        }
+    }
+    return $null
+}

--- a/K8sUtils/private/Write-PodLog.ps1
+++ b/K8sUtils/private/Write-PodLog.ps1
@@ -23,11 +23,9 @@ Log level to use for the header, defaults to ok
 .PARAMETER LogFileFolder
 Optional folder to write the logs to
 
-.EXAMPLE
-An example
+.OUTPUTS
+Exit code for getting the logs, and if LogFileFolder is specified, the path to the log file
 
-.NOTES
-General notes
 #>
 function Write-PodLog {
     [CmdletBinding()]
@@ -51,7 +49,7 @@ function Write-PodLog {
     $msg = "Logs for $prefix $PodName"
     if ($Since) {
         $msg += " since ${Since}"
-        $extraLogParams += "--since=$logSeconds"
+        $extraLogParams += "--since=$Since"
     } elseif ($SinceTime) {
         $extraLogParams += "--since-time=$($SinceTime.ToString("o"))"
     }
@@ -73,7 +71,6 @@ function Write-PodLog {
     }
 
     Write-Debug ($podJson | Out-String)
-    Write-Header $msg -LogLevel $LogLevel
     $tempFile = Get-TempLogFile
     if ($LogFileFolder) {
         Start-Transcript -Path $tempFile -UseMinimalHeader | Out-Null
@@ -88,7 +85,15 @@ function Write-PodLog {
         $logs = kubectl logs --namespace $Namespace $PodName @extraLogParams 2>&1
         $getLogsExitCode = $LASTEXITCODE
     }
-    $logs | Where-Object { $_ -NotMatch 'Error.*: (PodInitializing|ContainerCreating)' } | Write-Plain
+
+    $outputLogs = $logs | Where-Object { $_ -NotMatch 'Error.*: (PodInitializing|ContainerCreating)' }
+    if ($outputLogs) {
+        Write-Header $msg -LogLevel $LogLevel
+        $outputLogs | Write-Plain
+        Write-Footer "End logs for $prefix $PodName"
+    } else {
+        Write-Status "$msg not found" -Length 0
+    }
 
     if ($LogFileFolder) {
         Stop-Transcript | Out-Null
@@ -100,7 +105,6 @@ function Write-PodLog {
         } | Out-File $logFilename -Append
         Remove-Item $tempFile -ErrorAction SilentlyContinue
     }
-    Write-Footer "End logs for $prefix $PodName"
 
     if ($getLogsExitCode -ne 0) {
         $msg = "Error getting logs for pod $PodName (exit = $getLogsExitCode), checking status"
@@ -136,5 +140,5 @@ function Write-PodLog {
             }
         }
     }
-    return $logFilename
+    return ($getLogsExitCode, $logFilename)
 }

--- a/K8sUtils/public/Get-K8sUtilsConfig.ps1
+++ b/K8sUtils/public/Get-K8sUtilsConfig.ps1
@@ -7,6 +7,7 @@ function Get-K8sUtilsConfig {
     [CmdletBinding()]
     param ()
     @{
+        AllowLowTimeouts = $script:AllowLowTimeouts
         UtcOffset = $script:UtcOffset
         LogVerboseStack = $script:LogVerboseStack
         UseThreadJobs = $script:UseThreadJobs

--- a/K8sUtils/public/Get-PodStatus.ps1
+++ b/K8sUtils/public/Get-PodStatus.ps1
@@ -223,7 +223,10 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
         $events = Get-PodEvent -Namespace $Namespace -PodName $pod.metadata.name
         if ($events) {
             $errors = @($events | Where-Object { $_.reason -eq "Killing" -or
-                                                 ($_.type -ne "Normal" -and $_.note -notlike "Startup probe failed:*" -and $_.reason -ne "FailedScheduling")})
+                                                 ($_.type -ne "Normal" -and
+                                                  $_.note -notlike "*probe*failed*" -and
+                                                  $_.note -notlike "*failed*probe*" -and
+                                                  $_.reason -ne "FailedScheduling")})
             Write-VerboseStatus "Got $($errors.count) error of $($events.count) events for pod $($pod.metadata.name) "
 
             if ($errors -or $pod.status.phase -eq "Failed" ) {
@@ -248,7 +251,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
                 }
 
                 $podStatuses[$pod.metadata.name].ContainerStatuses = @($pod.status.containerStatuses | ForEach-Object {
-                        Write-Debug "Pod status: $($_ | ConvertTo-Json -Depth 10)"
+                        Write-Debug "Failed pod status: $($_ | ConvertTo-Json -Depth 10)"
                         [ContainerStatus]::new($_.name, $_) })
                 if ($HasInit) {
                     $podStatuses[$pod.metadata.name].InitContainerStatuses = @($pod.status.initContainerStatuses | ForEach-Object { [ContainerStatus]::new($_.name, $_) })

--- a/K8sUtils/public/Get-PodStatus.ps1
+++ b/K8sUtils/public/Get-PodStatus.ps1
@@ -208,7 +208,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
                 ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel ok -HasInit:$HasInit -LogFileFolder $LogFileFolder
                 continue
             } else {
-                Write-VerboseStatus "Pod $($pod.metadata.name) is ready (phase = $okPhase), but pod containerStatuses are: $($pod.status.containerStatuses | out-string)"
+                Write-VerboseStatus "Pod $($pod.metadata.name) is ready (phase = $okPhase), but pod containerStatuses are: $($pod.status.containerStatuses | ConvertTo-Json -Depth 10 -EnumsAsStrings). This can occur for jobs where the pod is marked as Succeeded before all containers are marked as terminated with reason Completed. Will check containerStatuses for details."
             }
         }
 
@@ -230,44 +230,44 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
             Write-VerboseStatus "Got $($errors.count) error of $($events.count) events for pod $($pod.metadata.name) "
 
             if ($errors -or $pod.status.phase -eq "Failed" ) {
-                Write-Status "Failed pod $($pod.metadata.name) has $($errors.count) errors" -LogLevel Error
-                # write final events and logs for this pod
-                ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -HasInit:$HasInit -LogFileFolder $LogFileFolder
-                Write-VerboseStatus "Calling Get-AndWriteK8sEvent for pod $($pod.metadata.name) with LogLevel Error"
-                $podStatuses[$pod.metadata.name].LastBadEvents = Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -PassThru
+            Write-Status "Failed pod $($pod.metadata.name) has $($errors.count) errors" -LogLevel Error
+            # write final events and logs for this pod
+            ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -HasInit:$HasInit -LogFileFolder $LogFileFolder
+            Write-VerboseStatus "Calling Get-AndWriteK8sEvent for pod $($pod.metadata.name) with LogLevel Error"
+            $podStatuses[$pod.metadata.name].LastBadEvents = Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -PassThru
 
-                # get latest pod status since sometimes get containerCreating status here
-                $name = $pod.metadata.name
-                Write-VerboseStatus "kubectl get pod --namespace $Namespace $name -o json"
-                $podJson = kube get pod --namespace $Namespace $name -o json
-                if ($LASTEXITCODE -ne 0) {
-                    return $podStatuses.Values
-                }
-                $pod = $podJson | ConvertFrom-Json
-                if (!$pod -or !(Get-Member -InputObject $pod -Name metadata)) {
-                    Write-Warning "Unexpected response from kubectl get pod --namespace $Namespace $name JSON is: '$podJson'"
-                    # throw "Unexpected response from kubectl get pod --namespace $Namespace $name"
-                    return $podStatuses.Values
-                }
-
-                $podStatuses[$pod.metadata.name].ContainerStatuses = @($pod.status.containerStatuses | ForEach-Object {
-                        Write-Debug "Failed pod status: $($_ | ConvertTo-Json -Depth 10)"
-                        [ContainerStatus]::new($_.name, $_) })
-                if ($HasInit) {
-                    $podStatuses[$pod.metadata.name].InitContainerStatuses = @($pod.status.initContainerStatuses | ForEach-Object { [ContainerStatus]::new($_.name, $_) })
-                }
-                $podStatuses[$pod.metadata.name].DetermineStatus()
-                Write-Debug "Get-PodStatus returning $($podStatuses[$pod.metadata.name] | ConvertTo-Json -Depth 10 -EnumsAsStrings)"
+            # get latest pod status since sometimes get containerCreating status here
+            $name = $pod.metadata.name
+            Write-VerboseStatus "kubectl get pod --namespace $Namespace $name -o json"
+            $podJson = kube get pod --namespace $Namespace $name -o json
+            if ($LASTEXITCODE -ne 0) {
                 return $podStatuses.Values
-
-            } else {
-                if ($VerbosePreference -eq 'Continue') {
-                    Write-VerboseStatus "No errors found in events for pod $($pod.metadata.name) yet"
-
-                    Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Since $lastEventTime -Namespace $Namespace
-                }
-                ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Since "${logSeconds}s" -Namespace $Namespace -HasInit:$HasInit -LogFileFolder $LogFileFolder
             }
+            $pod = $podJson | ConvertFrom-Json
+            if (!$pod -or !(Get-Member -InputObject $pod -Name metadata)) {
+                Write-Warning "Unexpected response from kubectl get pod --namespace $Namespace $name JSON is: '$podJson'"
+                # throw "Unexpected response from kubectl get pod --namespace $Namespace $name"
+                return $podStatuses.Values
+            }
+
+            $podStatuses[$pod.metadata.name].ContainerStatuses = @($pod.status.containerStatuses | ForEach-Object {
+                    Write-Debug "Failed container status: $($_ | ConvertTo-Json -Depth 10)"
+                    [ContainerStatus]::new($_.name, $_) })
+            if ($HasInit) {
+                $podStatuses[$pod.metadata.name].InitContainerStatuses = @($pod.status.initContainerStatuses | ForEach-Object { [ContainerStatus]::new($_.name, $_) })
+            }
+            $podStatuses[$pod.metadata.name].DetermineStatus()
+            Write-Debug "Get-PodStatus returning $($podStatuses[$pod.metadata.name] | ConvertTo-Json -Depth 10 -EnumsAsStrings)"
+            return $podStatuses.Values
+
+        } else {
+            if ($VerbosePreference -eq 'Continue') {
+                Write-VerboseStatus "No errors found in events for pod $($pod.metadata.name) yet"
+
+                Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Since $lastEventTime -Namespace $Namespace
+            }
+            ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Since "${logSeconds}s" -Namespace $Namespace -HasInit:$HasInit -LogFileFolder $LogFileFolder
+        }
        } # else no events
        # TODO we've seen case where pod.status.containerStatuses.state.waiting has
        #   message: secret "eventhub-disabled-bootstrap-servers" not found

--- a/K8sUtils/public/Get-PodStatus.ps1
+++ b/K8sUtils/public/Get-PodStatus.ps1
@@ -91,10 +91,11 @@ function allContainersReady($containerStatuses) {
 
 $start = Get-Date
 $timeoutEnd = $start.AddSeconds($TimeoutSec)
-$logSeconds = "600s"
+$logSeconds = 600
 $extraSeconds = 1 # extra seconds to add to logSeconds to avoid missing something
 $lastEventTime = (Get-CurrentTime ([TimeSpan]::FromMinutes(-5)))
 $timedOut = $false
+$logExitCode = 0
 
 Write-Status "Checking status of pods of type $podType that match selector $Selector for ${TimeoutSec}s"
 $podCount = 0
@@ -204,7 +205,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
                                                                                 -LogLevel ok `
                                                                                 -FilterStartupWarnings
 
-                $podStatuses[$pod.metadata.name].PodLogFile = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel ok -HasInit:$HasInit -LogFileFolder $LogFileFolder
+                ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel ok -HasInit:$HasInit -LogFileFolder $LogFileFolder
                 continue
             } else {
                 Write-VerboseStatus "Pod $($pod.metadata.name) is ready (phase = $okPhase), but pod containerStatuses are: $($pod.status.containerStatuses | out-string)"
@@ -213,7 +214,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
 
         if ($timedOut) {
             Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel warning -FilterStartupWarnings
-            $podStatuses[$pod.metadata.name].PodLogFile = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel warning -HasInit:$HasInit -LogFileFolder $LogFileFolder
+            ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel warning -HasInit:$HasInit -LogFileFolder $LogFileFolder
             break
         }
 
@@ -228,7 +229,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
             if ($errors -or $pod.status.phase -eq "Failed" ) {
                 Write-Status "Failed pod $($pod.metadata.name) has $($errors.count) errors" -LogLevel Error
                 # write final events and logs for this pod
-                $podStatuses[$pod.metadata.name].PodLogFile = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -HasInit:$HasInit -LogFileFolder $LogFileFolder
+                ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -HasInit:$HasInit -LogFileFolder $LogFileFolder
                 Write-VerboseStatus "Calling Get-AndWriteK8sEvent for pod $($pod.metadata.name) with LogLevel Error"
                 $podStatuses[$pod.metadata.name].LastBadEvents = Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Namespace $Namespace -LogLevel Error -PassThru
 
@@ -262,7 +263,7 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
 
                     Get-AndWriteK8sEvent -Prefix $prefix -PodName $pod.metadata.name -Since $lastEventTime -Namespace $Namespace
                 }
-                $podStatuses[$pod.metadata.name].PodLogFile = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Since $logSeconds -Namespace $Namespace -HasInit:$HasInit -LogFileFolder $LogFileFolder
+                ($logExitCode, $podStatuses[$pod.metadata.name].PodLogFile) = Write-PodLog -Prefix $prefix -PodName $pod.metadata.name -Since "${logSeconds}s" -Namespace $Namespace -HasInit:$HasInit -LogFileFolder $LogFileFolder
             }
        } # else no events
        # TODO we've seen case where pod.status.containerStatuses.state.waiting has
@@ -281,7 +282,11 @@ while ($runningCount -lt $ReplicaCount -and !$timedOut)
     }
     Write-VerboseStatus "Sleeping $PollIntervalSec second$($PollIntervalSec -eq 1 ? '': 's'). Running Count = $runningCount ReplicaCount = $ReplicaCount"
     Start-Sleep -Seconds $PollIntervalSec
-    $logSeconds = "$($PollIntervalSec + $extraSeconds)s"
+    if ($logExitCode -eq 0) {
+        $logSeconds = $PollIntervalSec + $extraSeconds
+    } else {
+        $logSeconds += $PollIntervalSec
+    }
 } # end while check pods
 
 $ok = [bool]($runningCount -ge $ReplicaCount)

--- a/K8sUtils/public/Invoke-HelmUpgrade.ps1
+++ b/K8sUtils/public/Invoke-HelmUpgrade.ps1
@@ -205,7 +205,7 @@ function Invoke-HelmUpgrade {
         Write-Footer
     }
 
-    if ($env:K8sUtils_AllowLowTimeouts -ne 'true') {
+    if (!$script:AllowLowTimeouts) {
         if ($PreHookTimeoutSecs -lt $minPreHookTimeoutSecs) {
             Write-Warning "PreHookTimeoutSecs ($PreHookTimeoutSecs) is less than $minPreHookTimeoutSecs seconds, setting to $minPreHookTimeoutSecs."
             $PreHookTimeoutSecs = $minPreHookTimeoutSecs

--- a/K8sUtils/public/Set-K8sUtilsConfig.ps1
+++ b/K8sUtils/public/Set-K8sUtilsConfig.ps1
@@ -23,7 +23,8 @@ function Set-K8sUtilsConfig {
         [string] $ColorType = "DontSet",
         [int] $OffsetMinutes = -1,
         [switch] $LogVerboseStack,
-        [switch] $UseThreadJobs
+        [switch] $UseThreadJobs,
+        [switch] $AllowLowTimeouts
     )
     if ($OffsetMinutes -ge 0) {
         $script:UtcOffset = New-TimeSpan -Minutes $OffsetMinutes
@@ -32,6 +33,7 @@ function Set-K8sUtilsConfig {
     }
     $script:LogVerboseStack = [bool]$LogVerboseStack
     $script:UseThreadJobs = [bool]$UseThreadJobs
+    $script:AllowLowTimeouts = [bool]$AllowLowTimeouts
 
     if ($ColorType -eq "None" -or $env:NO_COLOR -eq "1") {
         $script:ColorType = "None"

--- a/K8sUtils/public/Start-PreHookJobThread.ps1
+++ b/K8sUtils/public/Start-PreHookJobThread.ps1
@@ -80,7 +80,7 @@ function Start-PreHookJobThread {
                                 -PreHookTimeoutSecs $using:PreHookTimeoutSecs `
                                 -Status $status) {
 
-                $inThreadPollIntervalSec = 1
+                $inThreadPollIntervalSec = 2
 
                 Get-PreHookJobStatus -PreHookJobName $using:PreHookJobName `
                                     -Namespace $using:Namespace `

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ In the `DevOps/Kubernetes` folder are the following manifests:
 | deploy-without-helm.yaml | Used for testing without Helm                                |
 | lock-down-secrets.yml    | Creates service accounts and roles for testing secret access |
 
-> Set `$env:invokeHelmAllowLowTimeouts=1` to allow short timeouts for testing, otherwise it will set the minimum to 120s for pre-install hook and 180s for main. Setting `$env:TF_BUILD=$true` will simulate running in an Azure DevOps pipeline and change header and footer output format.
+> `Set-K8sUtilsConfig -AllowLowTimeouts` to allow short timeouts for testing, otherwise it will set the minimum to 120s for pre-install hook and 180s for main. Setting `$env:TF_BUILD=$true` will simulate running in an Azure DevOps pipeline and change header and footer output format.
 
 ### Tested Scenarios <!-- omit in toc -->
 

--- a/Tools/Deploy-Minimal.ps1
+++ b/Tools/Deploy-Minimal.ps1
@@ -95,6 +95,12 @@ Container registry to use, defaults to docker.io
 .PARAMETER activeDeadlineSeconds
 How long to wait for the preHook job to complete before it is killed, defaults to 30 seconds
 
+.PARAMETER HookDelaySec
+Delay in seconds for the preHook job before it completes its work, defaults to 1 second
+
+.PARAMETER InitDelaySec
+Delay in seconds for the init container before it completes, defaults to 1 second
+
 .EXAMPLE
 Deploy-Minimal -PassThru -SkipInit -SkipPreHook -registry loyal.azurecr.io -ImageTag test-198145
 
@@ -135,7 +141,9 @@ function Deploy-Minimal {
         [string] $chartName = "minimal",
         [string] $ServiceAccount = "",
         [string] $registry = "docker.io",
-        [int] $activeDeadlineSeconds = 30
+        [int] $activeDeadlineSeconds = 30,
+        [int] $HookDelaySec = 1,
+        [int] $InitDelaySec = 1
 
     )
     Set-StrictMode -Version Latest
@@ -163,6 +171,10 @@ function Deploy-Minimal {
                 @{
                     name  = "FAIL"
                     value = $InitFail.ToString()
+                },
+                @{
+                    name  = "DELAY_SEC"
+                    value = $InitDelaySec.ToString()
                 }
             )
             volumeMounts  = @(
@@ -200,6 +212,7 @@ function Deploy-Minimal {
                 "preHook.fail=$HookFail",
                 "preHook.imageTag=$HookTag",
                 "preHook.runCount=$HookRunCount",
+                "preHook.delaySec=$HookDelaySec",
                 "preHook.cpuRequest=$HookCpuRequest",
                 "readinessPath=$Readiness",
                 "registry=$registry",

--- a/Tools/JobDeploy.tests.ps1
+++ b/Tools/JobDeploy.tests.ps1
@@ -3,7 +3,7 @@ BeforeAll {
     Import-Module $PSScriptRoot\..\K8sUtils\K8sUtils.psm1 -Force -ArgumentList $true
     Import-Module $PSScriptRoot\Minimal.psm1 -Force -ArgumentList $true
 
-    $env:K8sUtils_AllowLowTimeouts = $true
+    Set-K8sUtilsConfig -AllowLowTimeouts
 
     . $PSScriptRoot\TestHelpers.ps1
 }

--- a/Tools/JobDeployK8s.tests.ps1
+++ b/Tools/JobDeployK8s.tests.ps1
@@ -3,7 +3,7 @@ BeforeAll {
     Import-Module $PSScriptRoot\Minimal.psm1 -Force -ArgumentList $true
     Import-Module  $PSScriptRoot\..\K8sUtils\K8sUtils.psm1 -Force -ArgumentList $true
 
-    $env:K8sUtils_AllowLowTimeouts = $true
+    Set-K8sUtilsConfig -AllowLowTimeouts
 
     . $PSScriptRoot\TestHelpers.ps1
 }

--- a/Tools/Minimal.psm1
+++ b/Tools/Minimal.psm1
@@ -1,6 +1,7 @@
 param( [bool] $Quiet = $false)
 
-$env:K8sUtils_AllowLowTimeouts=1
+Set-K8sUtilsConfig -AllowLowTimeouts
+
 
 $exports = @()
 Get-ChildItem $PSScriptRoot\*.ps1 | Where-Object { $_ -notlike '*.tests.ps1' } | ForEach-Object { . $_; $exports += $_.BaseName }

--- a/Tools/MinimalDeploy.tests.ps1
+++ b/Tools/MinimalDeploy.tests.ps1
@@ -3,7 +3,8 @@ BeforeAll {
     Import-Module $PSScriptRoot\..\K8sUtils\K8sUtils.psm1 -Force -ArgumentList $true
     Import-Module $PSScriptRoot\Minimal.psm1 -Force -ArgumentList $true
 
-    $env:K8sUtils_AllowLowTimeouts = $true
+    Set-K8sUtilsConfig -AllowLowTimeouts
+
     Get-K8sUtilsConfig
 
     . $PSScriptRoot\TestHelpers.ps1


### PR DESCRIPTION
### Changed

- Update pre-install hook log retrieval to get first lines that may be lost
- Suppress logging header and footer if there are no logs when polling for them.
- `Set-K8sUtilsConfig -AllowLowTimeouts` switch added instead of using environment variable. This is a breaking change, but only affects testing.
- Added DELAY_SEC parameter for testing in the minimal app. Depends on using the latest minimal app.
- Update bad pod reason detection by using restart count

### Fixed

- Bug in Get-PodStatus the --since parameter was using the wrong variable


- [x] CHANGELOG.md updated
- [x] K8sUtils.psd1 version number updated
- [x] K8sUtils.psd1 FunctionsToExport or AliasesToExport updated if added a new function
- [x] New tests added
